### PR TITLE
Update dialogmenu.cpp - DialogMenu::skipPhrase + stopDlgAnim();

### DIFF
--- a/game/ui/dialogmenu.cpp
+++ b/game/ui/dialogmenu.cpp
@@ -379,10 +379,14 @@ void DialogMenu::startTrade() {
 
 void DialogMenu::skipPhrase() {
   if(current.time>0) {
-    if(pl!=nullptr)
-      pl->setAiOutputBarrier(0,false);
-    if(other!=nullptr)
-      other->setAiOutputBarrier(0,false);
+    if (pl != nullptr) {
+      pl->setAiOutputBarrier(0, false);
+      pl->stopDlgAnim(); //skip pl-dialog phrase
+    }
+    if (other != nullptr) {
+      other->setAiOutputBarrier(0, false);
+      other->stopDlgAnim(); //skip other-dialog phrase
+    }
     currentSnd   = SoundEffect();
     current.time = 1;
     }


### PR DESCRIPTION
Fixes lip sync when skipping dialogues the lips sync now looks really good.